### PR TITLE
Fix typos in the sessions

### DIFF
--- a/content/participant-remote/Camilo-Cota.md
+++ b/content/participant-remote/Camilo-Cota.md
@@ -11,7 +11,7 @@ twitter         :
 facebook        :
 website         :
 sessions        :
-  - Secret Management
-  - Dealing with DevSecOps Finding
+  - Secrets Management
+  - Dealing with DevSecOps Findings
   - From Threat Modeling to DevSecOps metrics
 ---


### PR DESCRIPTION
Should be 'Secrets Management' and 'Dealing with DevSecOps Findings' .. both are missing a final 's